### PR TITLE
Load swagger Javascript from static

### DIFF
--- a/flasgger/ui3/static/swagger.js
+++ b/flasgger/ui3/static/swagger.js
@@ -1,0 +1,29 @@
+window.onload = function() {
+    // This is a rendered version of swagger.html
+    const ui = SwaggerUIBundle(
+      Object.assign(
+        {
+          url: "/swagger_api/apispec.json",
+          dom_id: '#swagger-ui',
+          validatorUrl: null,
+          displayOperationId: true,
+          deepLinking: true,
+          jsonEditor: true,
+          apisSorter: "alpha",
+          presets: [
+              SwaggerUIBundle.presets.apis,
+              SwaggerUIStandalonePreset
+          ],
+          plugins: [
+              SwaggerUIBundle.plugins.DownloadUrl
+          ],
+          layout: "StandaloneLayout",
+        },
+        {}
+      )
+    )
+    let auth_config = null;
+    ui.initOAuth(auth_config);
+    window.ui = ui
+    $(".topbar-wrapper .link span").replaceWith("<span>Flasgger</span>");
+}

--- a/flasgger/ui3/templates/flasgger/head.html
+++ b/flasgger/ui3/templates/flasgger/head.html
@@ -4,6 +4,7 @@
 <link rel="stylesheet" type="text/css" href="{{ swagger_ui_css }}">
 <!-- Customize the app.config['SWAGGER']['favicon'] -->
 <link rel="icon" type="image/png" href="{{ favicon }}" sizes="64x64 32x32 16x16" />
+<script src='{{url_for('flasgger.static', filename='')}}swagger.js' type='text/javascript'></script>
 <style>
     html
     {


### PR DESCRIPTION
The original swagger.html contained jinja templating, but there is no (easy) way to render swagger.js through templating via apidocs routing so I used the rendered template from SRAM test to create the static version.
This means that any conditional content (config/auth) can not be enabled through flasgger configuration after merging this PR.

Related issue https://github.com/SURFscz/SBS/issues/293